### PR TITLE
아이템38-확장할 수 있는 열거타입이 필요하면 인터페이스를 사용하라

### DIFF
--- a/6장- 열거타입과 애너테이션/아이템38-확장할 수 있는 열거타입이 필요하면 인터페이스를 사용하라.md
+++ b/6장- 열거타입과 애너테이션/아이템38-확장할 수 있는 열거타입이 필요하면 인터페이스를 사용하라.md
@@ -1,0 +1,98 @@
+
+## 선정리
+- java에서는 enum에 메서드를 추가해서 객체지향적으로 타입이 어떠한 메서드를 가질 수 있다.
+- 사내에서 지마켓이냐 옥션이냐에 따라 분기문이 많이 발생하는데 enum을 사용해서 지마켓상품,옥션상품인지를 판별하는 메서드를 enum에 추가해서 사용해본 경험이 있다. 그런데 enum을 확장해서까지 사용하면 얻을 수 있는 장점이 큰지는 잘 모르겠다.
+- 책에서 나온내용처럼 연산자정도에서는 나름 유용하게 사용가능할것 같다.
+
+## 타입열거안전타입
+- 열거타입은 거의 모든상황에서 타입 안전 열거패턴보다 우수하다고 한다. 타입열거안전타입은 또 뭐야...?
+- enum이 등장하기전에 사용하던 패턴임
+ ```java
+ public class Suit {
+    private final String name;
+
+    public static final Suit CLUBS =new Suit("clubs");
+    public static final Suit DIAMONDS =new Suit("diamonds");
+    public static final Suit HEARTS =new Suit("hearts");
+    public static final Suit SPADES =new Suit("spades");    
+
+    private Suit(String name){
+        this.name =name;
+    }
+
+    public String toString(){
+        return name;
+    }
+}
+ 
+ ```
+ 
+ ## 타입열거안전타입보다는 열거타입이 더 안전하지만 확장이 불가능하다
+- 위의코드에서 본것처럼 타입열거안전타입은 클래스기반이기때문에 확장이 가능하지만 enum은 기본적으로 확장이 불가능하다.
+- 또한, 열거타입은 일반적으로 `확장에 적합하지 않다.`
+- `만약 확장해야한다면 인터페이스를 사용`하라고 저자가 제시해준다.
+- `근데 열거타입으로 이렇게까지 하는게 좋은 방법일까에 의문이 든다.`
+- 하지만, 연산코드의 경우에는 열거타입을 확장하는게 도움이 된다고한다. (api가 제공하는 기본연산 외에 확장 연산을 추가할 수 있도록 열어줘야 한다면 열거타입을 확장시켜줘야한다)
+
+
+```java
+
+public interface Operation {
+    double apply(double x, double y);
+
+
+```
+
+
+```java
+
+public enum BasicOperation implements Operationn {
+    PLUS("+") {
+        public double apply(double x, double y) { return x + y; }
+    },
+    MINUS("-") {
+        public double apply(double x, double y) { return x - y; }
+    },
+    TIMES("*") {
+        public double apply(double x, double y) { return x * y; }
+    },
+    DIVIDE("/") {
+        public double apply(double x, double y) { return x / y; }
+    };
+    
+    private final String symbol;
+    
+    BasicOperation(String symbol) {
+        this.symbol = symbol;
+    }
+    
+    @Override
+    public String toString() {
+        return symbol;
+    }
+}
+
+
+```
+
+
+```java
+
+public enum ExtendedOperation implements Operation {
+    EXP("^") {
+        public double apply(double x, double y) {
+            return Math.pow(x, y);
+        }
+    },
+    REMAINDER("%") {
+        public double apply(double x, double y) {
+            return x % y;
+        }
+    };
+    
+    private final String symbol;
+    ...
+}
+
+
+```

--- a/6장- 열거타입과 애너테이션/아이템41 - 정의하려는 것이 타입이라면 마커 인터페이스를 사용하라.md
+++ b/6장- 열거타입과 애너테이션/아이템41 - 정의하려는 것이 타입이라면 마커 인터페이스를 사용하라.md
@@ -1,0 +1,99 @@
+# 마커인터페이스
+
+- 메서드가 없고, 단지 `자신을 구현하는 클래스가 특정 속성을 가짐을 표시해주는 인터페이스를 마커 인터페이스`라고 부른다.
+- 대표적으로 Serializable인터페이스가 있다. Serializable을 구현한 구현체는 ObjectOutputStream을 통해 write할 수 있다고 알려준다.
+- 마커 인터페이스는 마크애너테이션보다 적용 대상을 더 정밀하게 지정할 수 있다.
+- 마커 인터페이스는 이를 구현한 클래스의 인스턴스들을 구분하는 타입으로 쓸 수 있다.
+```java
+
+class SomeObject implements Serializable { 
+	private String name;
+	private String email;
+	public SomeObject(String name, String email) {
+		super();
+		this.name = name;
+		this.email = email;
+	}
+}
+
+public class MarkerInterfaceTest {
+	public static void main(String[] args) throws FileNotFoundException, IOException, ClassNotFoundException {
+		serializableTest();
+	}
+	
+	  public static void serializableTest() throws IOException, ClassNotFoundException {
+		File f = new File("a.txt");
+    // Serializable를 구현하지 않은 상태로 직렬화를 하려고하면 java.io.NotSerializableException 발생
+		ObjectOutputStream objectOutputStream = new ObjectOutputStream(new FileOutputStream(f));
+		objectOutputStream.writeObject(new SomeObject("wonwoo", "test@test.com"));
+	}
+}
+
+```
+
+
+
+# 마커애너테이션
+
+- 아무 매개변수 없이 단순히 대상에 마킹(marking)한다"는 뜻에서 마커(marker) 애너테이션이라 한다.
+- 마커 인터페이스는 이를 구현한 클래스의 인스턴스들을 구분하는 타입으로 쓸 수 있으나, 마커 애너테이션은 그렇지 않다.
+- 인터페이스와 다르게 새로운 정보를 추가시키는게 유연하다(인터페이스는 구현체가 여러개있다면 하위호환성을 지키기 어렵지만 애노테이션은 default값을 갖도록 설정할 수 있으므로)
+
+
+
+# 실제로 사용해본 경험
+
+
+스프링에서 bean validation을 처리할때 group에 따라 서로 다른 validation을 처리해야할 경우가 있는데 이때 마커 인터페이스를 활용할 수 있다.
+사용하려는 validation annotation의 group에 어떤 group인지 선언해주면 해당 그룹에 속하는 validation로직만 수행한다.
+
+
+```java
+
+interface OnCreate {}
+
+interface OnUpdate {}
+
+
+```
+
+
+```java
+
+class InputEntityWithCustomValidator {
+
+  @Null(groups = OnCreate.class)
+  @NotNull(groups = OnUpdate.class)
+  private Long id;
+  
+  // ...
+}
+
+
+```
+
+
+```java
+
+@Service
+@Validated
+public class ValidateServiceWithGroups {
+
+    @Validated(OnCreate.class)
+    void validateForCreate(@Valid InputEntityWithCustomValidator input) {
+        // do something
+    }
+
+    @Validated(OnUpdate.class)
+    void validateForUpdate(@Valid InputEntityWithCustomValidator input) {
+        // do something
+    }
+}
+
+```
+
+
+# 정리
+- 새로 추가하는 메서드 없이 단지 타입 정의가 목적이라면 마커 인터페이스를 사용
+- 클래스나 인터페이스 외에 프로그램 요소에 마킹해야하거나 애너테이션을 적극적으로 활용하는 프레임워크의 일부로 해당 마커를 사용한다면 마커 애너테이션을 사용
+ - 위의 예시처럼 스프링을 사용한다면 마커인터페이스와 마커애너테이션을 모두 사용해서 bean validation을 처리한다.


### PR DESCRIPTION
enum을 확장하는 방법을 소개해주고있습니다.. 하지만 enum을 확장해서 까지 사용하는 경우가 있을지는 조금 의문이 들었습니다. enum을 확장해야하는 수준이면 단순하게 타입을 열거해주는 책임을 넘어서기때문에 그냥 enum + class를 적절하게 조합해서 사용하는게 더 좋지 않을까하는 생각이 들었습니다.