### PR TITLE
아이템 42장. 익명 클래스보다는 람다를 사용하라

### DIFF
--- a/6장- 열거타입과 애너테이션/42장 익명 클래스보다는 람다를 사용하라.md
+++ b/6장- 열거타입과 애너테이션/42장 익명 클래스보다는 람다를 사용하라.md
@@ -1,0 +1,117 @@
+# 42장. 익명 클래스보다는 람다를 사용하라
+
+## 익명 클래스
+
+```java
+@DisplayName("자바8 이전에 사용하던 익명클래스")
+void anonymousClass() {
+  List<String> word = new ArrayList<>(List.of("A","BCD","EF"));
+  Collections.sort(word, new Comparator<String>() {
+    @Override
+    public int compare(String o1, String o2) {
+      return Integer.compare(o1.length(), o2.length());
+    }
+  });
+
+}
+```
+
+람다 이전에 함수 객체를 사용하던 방법으로, 추상메서드 하나만 담은 인터페이스 또는 추상 클래스를 사용했다.
+
+그러나 코드가 너무 길어져 함수형 프로그래밍에 적합하지 않았다.
+
+## 람다 표현식
+
+```java
+Collections.sort(words, (s1, s2) -> Integer.compare(s1.length(), s2.length()));
+```
+
+자바 8부터 추상 메서드 하나만 가지는 인터페이스를 `함수형 인터페이스`라고 부른다.
+
+함수형 인터페이스의 인스턴스를 `람다`로 바꾸며, 익명 클래스와 비슷한 개념이지만 코드가 훨씬 간결하다.
+
+컴파일러가 문맥을 살펴 람다식의 타입을 추론한다.
+
+→ 람다 타입: Comparator, 매개변수 타입: String, 반환값 타입: int
+
+컴파일러가 타입추론을 할때 정보를 얻는 방법은 **대부분 제네릭**을 통해 얻는다.
+
+만약 위의 예제에서 **List<String>** 이 아니라 로 타입인 List 였다면 컴파일 오류가 발생한다.
+
+## 열거형에 ****함수 인스턴스 필드 저장****
+
+```java
+public enum Operation {
+	PLUS("+", (x, y) -> x + y),
+	MINUS("-", (x, y) -> x - y),
+	TIMES("*", (x, y) -> x * y),
+	DIVIDE("/", (x, y) -> x / y);
+
+	private final String symbol;
+	private final DoubleBinaryOperator op;
+
+	Operation(String symbol, DoubleBinaryOperator op) {
+		this.symbol = symbol;
+		this.op = op;
+	}
+
+	@Override public String toString() {
+		return symbol;
+	}
+
+	public double apply(double x, double y) {
+		return op.applyAsDouble(x, y);
+	}
+}
+```
+
+함수객체(람다)를 인스턴스 필드에 저장해서 보기 편한 코드로 사용하고, 
+
+각 타입마다 메서드가 다르게 작동하도록 구현되었다.
+
+람다 방식으로 구현하면 코드가 매우 깔끔해진다.
+
+## 람다의 한계점
+
+1. 람다는 이름이 없고 문서화를 하기 어렵다.
+    
+    → 코드 자체로 동작이 명확히 설명되지 않거나 코드 줄 수가 많아지면 람다를 사용하지말아야한다.
+    
+2. 열거 타입 생성자에 넘겨지는 인수들의 타입도 컴파일 타임에 추론되므로, 열거 타입 생성자 안의 람다는 열거타입의 인스턴스 맴버에 접근할 수 없다.
+3. 람다는 자신을 참조할 수 없다.
+    
+    → 람다에서의 this 키워드는 바깥 인스턴스를 가리킨다.
+    
+
+```java
+public interface Foo {
+  int anyThing(int i);
+}
+
+public class Test {
+  private final int value = 20;
+  public Foo foo = new Foo() {
+    final int value = 10;
+    @Override
+    public int anyThing(int i) {
+      return i + this.value; //인스턴스 자신
+    }
+  };
+  public Foo foo2 = i -> i + this.value; //바깥 인스턴스
+
+}
+```
+
+## **주의사항**
+
+람다도 익명 클래스처럼 직렬화 형태가 구현별로(가상 머신 별로) 다를 수 있다.
+
+따라서 람다를 직렬화 하는 일은 극히 삼가야 한다.
+
+직렬화를 해야 할 함수 객체가 있다면 private 중첩클래스의 인스턴스를 사용해야한다.
+
+## 정리
+
+람다는 간단하게 표현할 수 있을 정도의 코드에서만 사용을 하는 것이 효율적이다.
+
+람다를 사용하지 못하는 경우에는 익명클래스를 사용하도록 하자.


### PR DESCRIPTION
간단하게 요약을하자면,
자바 8버전 이전에는 익명클래스를 사용을 했고, 이후에는 람다식을 활용하는 일들이 많아졌습니다.
람다식을 이용하면 코드를 간단하게 표현할 수 있으나, 복잡한 코드등등과 같이 적절하게 사용하지 못하는 케이스도 있습니다. 이런 경우에 대해서 확인 할 수 있으니 살펴보시면 될 것 같습니다.