### PR TITLE
아이템 73. 추상화 수준에 맞는 예외를 던져라.md

### DIFF
--- a/9장 - 일반적인 프로그래밍 원칙/아이템 73. 추상화 수준에 맞는 예외를 던져라.md
+++ b/9장 - 일반적인 프로그래밍 원칙/아이템 73. 추상화 수준에 맞는 예외를 던져라.md
@@ -1,0 +1,102 @@
+# 73장. 추상화 수준에 맞는 예외를 던져라
+
+![Untitled](73%E1%84%8C%E1%85%A1%E1%86%BC%20%E1%84%8E%E1%85%AE%E1%84%89%E1%85%A1%E1%86%BC%E1%84%92%E1%85%AA%20%E1%84%89%E1%85%AE%E1%84%8C%E1%85%AE%E1%86%AB%E1%84%8B%E1%85%A6%20%E1%84%86%E1%85%A1%E1%86%BD%E1%84%82%E1%85%B3%E1%86%AB%20%E1%84%8B%E1%85%A8%E1%84%8B%E1%85%AC%E1%84%85%E1%85%B3%E1%86%AF%20%E1%84%83%E1%85%A5%E1%86%AB%E1%84%8C%E1%85%A7%E1%84%85%E1%85%A1%2073c3479fdb0d482aa3b682ff40b6775e/Untitled.png)
+
+자바에서 에러는 크게 두 갈래로 나눌 수 있다.
+
+- error
+- exception
+
+Exception은 RunTimeException과 그 외 Exception 두 갈래로 다시 나뉜다.
+
+다이어그램을 자세히 보면 RuntimeException은 Unckecked, 
+
+그 외 Exception은 Checked라고 표시되어 있다.
+
+## **예외 번역(Exception Translation), 예외 전환**
+
+상위 계층에서 저수준 예외를 잡아 자신의 추상화 수준에 맞는 예외로 바꿔 던지는 것
+
+### 사용 목적
+
+1. 내부에서 발생한 예외를 던지는 것이 상황에 대한 적절한 의미를 부여하지 못하는 경우 의미를 분명하게 해줄 수 있는 예외로 바꿔주기 위해서
+2. 체크 예외를 런타임 에러로 바꾸기 위해 추상화 수준이 낮은 곳에서 높은 곳으로 예외를 발생시킬 경우, 메서드가 하는 일과 뚜렷한 관련성 없는 예외가 메서드에서 발생하기 때문에 낮은 곳에서 받은 예외를 상위 계층의 예외로 번역하여 사용해야 한다.
+
+```java
+//예외 번역
+try {
+//낮은 수준의 추상화 계층 이용
+} catch(LowerLevelException e) {
+throw new HigherLevelException();
+}
+```
+
+AbstractSequentialList 예제(의미 있는 예외로 변환하여 던지는 예시)
+
+```java
+public E get(int index) {
+    ListIterator<E> i  = listIterator(index);
+    try {
+        return i.next();
+    } catch (NoSuchElementException e) {
+        throw new IndexOutOfBoundsException();
+    }
+}
+```
+
+SQLException 은 대표적인 체크 예외이고며, 대부분 복구가 불가능하다.
+
+그래서 아래의 예시와 같이 처리해 줄 수 있는 것은 처리하고, 처리할 수 없는 것은 런타임 에러로 포장하여 호출하는 쪽에서 무차별 throws를 선언하지 않도록 해주는 것이 좋다.
+
+```java
+try {
+
+} catch (SQLException e) {
+    if(e.getErrorCode() 등을 이용해서 처리할 수 있는 경우){
+        // 처리 코드
+    } else{
+        // 로깅, 에러 내용 메일 전송 등의 로직
+        throw new RuntimeException(e);
+    }
+}
+```
+
+## **예외 연쇄(Exception Chaining)**
+
+하위 계층에서 발생한 예외 정보가 상위 계층 예외를 발생시킨 문제를 디버깅하는데 유용할 때
+
+- 하위 계층 예외(원인 cause)는 상위 계층 예외로 전달된다, 상위 계층 예외의 접근자 메서드(Throwble.getCause)를 호출하면 해당 정보를 꺼낼 수 있다.
+
+```java
+//예외 연결
+try {
+    //낮은 수준의 추상화 계층 이용
+} catch(LowerLevelException e) {
+    throw new HigherLevelException(cause);
+}
+```
+
+```java
+public static void main(String[] args) {
+        try {
+            // 예외 생성
+            NumberFormatException ex = new NumberFormatException("Exception");
+
+            ex.initCause(new NullPointerException("근본 원인"));
+            throw ex;
+        } catch (NumberFormatException ex) {
+            ex.getCause().printStackTrace();
+        }
+
+        //checked exception ->unchecked exception
+        throw new RuntimeException(new Exception("런타임 예외로 변경"));
+    }
+```
+
+예외 연결을 사용하면 프로그램 안에서 예외의 원인에 접근할 수 있을 뿐 아니라, 최초에 발생한 예외의 스택 추적 정보를 상위 계층 예외에 통합할 수 있다.
+
+## 결론
+
+예외변환을 남용하는 것보다 에러없는 코딩을 하는 것이 더 낫다.
+
+하위계층에서 발생한 에러는 하위계층에서 처리하고, 전달되어야 하는 경우에는 적절한 예외로 예외 변환해서 보내야 한다.


### PR DESCRIPTION
이전에 예외처리시에 나왔던 내용들과 유사한 부분이 있네요.

1. 예외변환을 남용하는 것보다 에러없는 코딩을 하는 것이 더 낫다.
2. 하위계층에서 발생한 에러는 하위계층에서 처리하고, 전달되어야 하는 경우에는 적절한 예외로 예외 변환해서 보내야 한다.